### PR TITLE
fix string equality testing against turtlecoin config string

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -226,7 +226,7 @@ void minethd::work_main()
 			}
 			version = new_version;
 		}
-        if (::jconf::inst()->GetMiningCoin().c_str() == "turtlecoin")
+        if (strcmp(::jconf::inst()->GetMiningCoin().c_str(), "turtlecoin") == 0)
         {
             miner_algo = ::jconf::inst()->GetMiningAlgo();
 			hash_fun = cpu::minethd::func_selector(::jconf::inst()->HaveHardwareAes(), true /*bNoPrefetch*/, miner_algo);

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -470,7 +470,7 @@ void minethd::work_main()
 			}
 			version = new_version;
 		}
-        if (::jconf::inst()->GetMiningCoin().c_str() == "turtlecoin")
+		if (strcmp(::jconf::inst()->GetMiningCoin().c_str(), "turtlecoin") == 0)
         {
             miner_algo = ::jconf::inst()->GetMiningAlgo();
 			hash_fun = func_selector(::jconf::inst()->HaveHardwareAes(), bNoPrefetch, miner_algo);

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -273,7 +273,7 @@ void minethd::work_main()
 			}
 			version = new_version;
 		}
-        if (::jconf::inst()->GetMiningCoin().c_str() == "turtlecoin")
+        if (strcmp(::jconf::inst()->GetMiningCoin().c_str(), "turtlecoin") == 0)
         {
             miner_algo = ::jconf::inst()->GetMiningAlgo();
 			hash_fun = cpu::minethd::func_selector(::jconf::inst()->HaveHardwareAes(), true /*bNoPrefetch*/, miner_algo);


### PR DESCRIPTION
Make string comparisons use strcmp instead of "==", since the latter is buggy and always results in false.

I found this bug because trtl-stak would not work with my pool software at http://cryptonote.social/ 

It seems other pools have managed to work around this problem, perhaps unwittingly.  It would still be good to get this fixed.